### PR TITLE
use overloads to split out connectionOptions and transportType while ensuring type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const handleSubmit = (user, message) => {
 ### Configure defaults
 ```ts
 signalR.setDefaults({
-  connectionOptionsOrTransportType: {
+  connectionOptions: {
     accessTokenFactory: () => user.userData.token
   },
   automaticReconnect: false
@@ -64,7 +64,8 @@ const signalRHub = signalR.useHub(hubUrl, {
   onError,
   enabled,
   automaticReconnect,
-  connectionOptionsOrTransportType,
+  connectionOptions,
+  transportType,
   hubProtocol,
   logging
 })
@@ -79,7 +80,8 @@ onReconnected?: (connectionId?: string) => void
 onError?: (error?: Error) => void
 enabled?: boolean
 automaticReconnect?: number[] | IRetryPolicy | boolean
-connectionOptionsOrTransportType?: IHttpConnectionOptions | HttpTransportType
+connectionOptions?: IHttpConnectionOptions
+transportType?: HttpTransportType
 hubProtocol?: IHubProtocol
 logging?: LogLevel | string | ILogger
 ```

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { Options } from "./types";
+import { Options, OOptions, TOptions } from "./types";
 
 const DEFAULTS: Options = {
   enabled: true
@@ -6,9 +6,11 @@ const DEFAULTS: Options = {
 
 export let defaultOptions: Options = DEFAULTS;
 
-export const setDefaults = (options: Options) => {
+export function setDefaults(options: OOptions): void
+export function setDefaults(options: TOptions): void
+export function setDefaults(options: Options) {
   defaultOptions = {
     ...DEFAULTS,
     ...options
   };
-};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import {
   IRetryPolicy
 } from "@microsoft/signalr";
 
-export interface Options {
+export interface OOptions {
   onConnected?: (hub: HubConnection) => void;
   onDisconnected?: (error?: Error) => void;
   onReconnecting?: (error?: Error) => void;
@@ -16,7 +16,22 @@ export interface Options {
   onError?: (error?: Error) => void;
   enabled?: boolean;
   automaticReconnect?: number[] | IRetryPolicy | boolean;
-  connectionOptionsOrTransportType?: IHttpConnectionOptions | HttpTransportType;
+  connectionOptions?: IHttpConnectionOptions;
   hubProtocol?: IHubProtocol;
   logging?: LogLevel | string | ILogger;
 }
+
+export interface TOptions {
+  onConnected?: (hub: HubConnection) => void;
+  onDisconnected?: (error?: Error) => void;
+  onReconnecting?: (error?: Error) => void;
+  onReconnected?: (connectionId?: string) => void;
+  onError?: (error?: Error) => void;
+  enabled?: boolean;
+  automaticReconnect?: number[] | IRetryPolicy | boolean;
+  transportType?: HttpTransportType;
+  hubProtocol?: IHubProtocol;
+  logging?: LogLevel | string | ILogger;
+}
+
+export type Options = OOptions | TOptions;

--- a/src/useSignalRHub.ts
+++ b/src/useSignalRHub.ts
@@ -5,12 +5,14 @@ import {
   HubConnectionState
 } from "@microsoft/signalr";
 
-import { Options } from "./types";
+import { Options, OOptions, TOptions } from "./types";
 import { defaultOptions } from "./globals";
 
+export default function useSignalRHub(hubUrl: string, options?: OOptions): HubConnection | null;
+export default function useSignalRHub(hubUrl: string, options?: TOptions): HubConnection | null;
 export default function useSignalRHub(hubUrl: string, options?: Options) {
   const [signalRHub, setSignalRHub] = useState<HubConnection | null>(null);
-  const optionsRef = useRef<Options>({...defaultOptions, ...options});
+  const optionsRef = useRef<OOptions & TOptions>({...defaultOptions, ...options});
 
   useEffect(() => {
     optionsRef.current = {...defaultOptions, ...options};
@@ -24,9 +26,10 @@ export default function useSignalRHub(hubUrl: string, options?: Options) {
 
     const hubConnectionSetup = new HubConnectionBuilder();
 
-    if(optionsRef.current.connectionOptionsOrTransportType)
-      // @ts-expect-error: We don't need to adhere to the overloads. https://github.com/microsoft/TypeScript/issues/14107
-      hubConnectionSetup.withUrl(hubUrl, optionsRef.current.connectionOptionsOrTransportType);
+    if(optionsRef.current.connectionOptions)
+      hubConnectionSetup.withUrl(hubUrl, optionsRef.current.connectionOptions);
+    else if (optionsRef.current.transportType)
+      hubConnectionSetup.withUrl(hubUrl, optionsRef.current.transportType);
     else
       hubConnectionSetup.withUrl(hubUrl);
 


### PR DESCRIPTION
SignalR has the following overloads for `withUrl`:
```ts
withUrl(url: string): HubConnectionBuilder;
withUrl(url: string, transportType: HttpTransportType): HubConnectionBuilder;
withUrl(url: string, options: IHttpConnectionOptions): HubConnectionBuilder;
```
As one can see from the overloads the `connectionOptions` and `transportType` are mutually exclusive.

As it is currently our api has a single combined field for it:
```ts
connectionOptionsOrTransportType?: IHttpConnectionOptions | HttpTransportType;
```

This works great but feels overly verbose thus ideally we would like to split them out into separate `connectionOptions` and `transportType` fields.
One way to achieve this is by updating useSignalRHub to to use the following for withUrl logic:
```ts
if(optionsRef.current.connectionOptions)
  hubConnectionSetup.withUrl(hubUrl, optionsRef.current.connectionOptions);
else if (optionsRef.current.transportType)
  hubConnectionSetup.withUrl(hubUrl, optionsRef.current.transportType);
else
  hubConnectionSetup.withUrl(hubUrl);
```
Problem here is that we arbitrarily have to decide that `connectionOptions` takes precedence over `transportType` and the user will be confused if they try to supply both. The types allow it without complaints.

We want clear type errors for when someone tried to apply both `connectionOptions` and `transportType` at the same time.
From experimentation using overloads seems to be the most type safe and shows clear type errors like we want:
<img width="1130" height="358" alt="image" src="https://github.com/user-attachments/assets/8285cf4b-27ad-4773-9e4e-69dcc6de85d4" />
