### PR TITLE
Change from connectionOptionsOrTransportType to only connectionOption…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ $ yarn add use-signalr-hub @microsoft/signalr
 ```
 
 ### Import into your project
-```tsx
+```ts
 import signalR from "use-signalr-hub"
 ```
 ### Use in your React component
-```tsx
+```ts
 const signalRHub = signalR.useHub("https://www.example.com/hub", {
   onConnected: (hub) => {
     // Connected to hub
@@ -47,7 +47,7 @@ const handleSubmit = (user, message) => {
 ### Configure defaults
 ```ts
 signalR.setDefaults({
-  connectionOptionsOrTransportType: {
+  connectionOptions: {
     accessTokenFactory: () => user.userData.token
   },
   automaticReconnect: false
@@ -64,7 +64,7 @@ const signalRHub = signalR.useHub(hubUrl, {
   onError,
   enabled,
   automaticReconnect,
-  connectionOptionsOrTransportType,
+  connectionOptions,
   hubProtocol,
   logging
 })
@@ -79,7 +79,7 @@ onReconnected?: (connectionId?: string) => void
 onError?: (error?: Error) => void
 enabled?: boolean
 automaticReconnect?: number[] | IRetryPolicy | boolean
-connectionOptionsOrTransportType?: IHttpConnectionOptions | HttpTransportType
+connectionOptions?: IHttpConnectionOptions
 hubProtocol?: IHubProtocol
 logging?: LogLevel | string | ILogger
 ```
@@ -88,8 +88,6 @@ logging?: LogLevel | string | ILogger
 [IRetryPolicy](https://learn.microsoft.com/en-us/javascript/api/@microsoft/signalr/iretrypolicy)
 |
 [IHttpConnectionOptions](https://learn.microsoft.com/en-us/javascript/api/@microsoft/signalr/ihttpconnectionoptions)
-|
-[HttpTransportType](https://learn.microsoft.com/en-us/javascript/api/@microsoft/signalr/httptransporttype)
 |
 [IHubProtocol](https://learn.microsoft.com/en-us/javascript/api/@microsoft/signalr/ihubprotocol)
 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-signalr-hub",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Easy to use hook for signalr",
   "author": "Darhagonable",
   "license": "MIT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ import {
   IHttpConnectionOptions,
   LogLevel,
   ILogger,
-  HttpTransportType,
   IHubProtocol,
   IRetryPolicy
 } from "@microsoft/signalr";
@@ -16,7 +15,7 @@ export interface Options {
   onError?: (error?: Error) => void;
   enabled?: boolean;
   automaticReconnect?: number[] | IRetryPolicy | boolean;
-  connectionOptionsOrTransportType?: IHttpConnectionOptions | HttpTransportType;
+  connectionOptions?: IHttpConnectionOptions;
   hubProtocol?: IHubProtocol;
   logging?: LogLevel | string | ILogger;
 }

--- a/src/useSignalRHub.ts
+++ b/src/useSignalRHub.ts
@@ -24,17 +24,17 @@ export default function useSignalRHub(hubUrl: string, options?: Options) {
 
     const hubConnectionSetup = new HubConnectionBuilder();
 
-    if(optionsRef.current.connectionOptionsOrTransportType)
-      // @ts-expect-error: We don't need to adhere to the overloads. https://github.com/microsoft/TypeScript/issues/14107
-      hubConnectionSetup.withUrl(hubUrl, optionsRef.current.connectionOptionsOrTransportType);
+    if(optionsRef.current.connectionOptions)
+      hubConnectionSetup.withUrl(hubUrl, optionsRef.current.connectionOptions);
     else
       hubConnectionSetup.withUrl(hubUrl);
 
     if(optionsRef.current.automaticReconnect) {
       if(optionsRef.current.automaticReconnect === true)
         hubConnectionSetup.withAutomaticReconnect();
+      else if(Array.isArray(optionsRef.current.automaticReconnect))
+        hubConnectionSetup.withAutomaticReconnect(optionsRef.current.automaticReconnect);
       else
-        // @ts-expect-error: We don't need to adhere to the overloads. https://github.com/microsoft/TypeScript/issues/14107
         hubConnectionSetup.withAutomaticReconnect(optionsRef.current.automaticReconnect);
     }
 


### PR DESCRIPTION
Change from `connectionOptionsOrTransportType` to only `connectionOptions` since `transportType` can be configured within the `connectionOptions` anyways. also addresses uses of `ts-exepect-error`